### PR TITLE
Remove lazy loading of libraries in `deps`

### DIFF
--- a/src/deps.ts
+++ b/src/deps.ts
@@ -1,4 +1,3 @@
-// tslint:disable no-implicit-dependencies
 import chalk = require('chalk')
 
 import args = require('./args')
@@ -10,27 +9,18 @@ import validate = require('./validate')
 
 export const deps = {
   // local
-  get args(): typeof args { return fetch('./args') },
-  get flags(): typeof flags { return fetch('./flags') },
-  get parse(): typeof parse { return fetch('./parse') },
-  get validate(): typeof validate { return fetch('./validate') },
-  get renderList(): typeof list.renderList { return fetch('./list').renderList },
-  get errors(): typeof errors { return fetch('./errors') },
+  get args(): typeof args { return args },
+  get flags(): typeof flags { return flags },
+  get parse(): typeof parse { return parse },
+  get validate(): typeof validate { return validate },
+  get renderList(): typeof list.renderList { return list.renderList },
+  get errors(): typeof errors { return errors },
 
   // remote
   get chalk(): typeof chalk.default | undefined {
     try {
-      return fetch('chalk').default
+      return chalk.default
       // tslint:disable-next-line no-unused
     } catch (err) {}
   },
-}
-
-const cache: any = {}
-
-function fetch(s: string) {
-  if (!cache[s]) {
-    cache[s] = require(s)
-  }
-  return cache[s]
 }


### PR DESCRIPTION
Fixes #20

Using lazy loading breaks binaries created with tools like zeit/pkg
because `require` is invoked without a literal value.