### PR TITLE
Handle flags with multiple inputs without the flag before each input

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -47,10 +47,10 @@ export class Parser<T extends ParserInput, TFlags extends OutputFlags<T['flags']
   private readonly raw: ParsingToken[] = []
   private readonly booleanFlags: { [k: string]: Flags.IBooleanFlag<any> }
   private readonly context: any
-  private currentFlag: Flags.IOptionFlag<any> | null
+  private currentFlag: Flags.IOptionFlag<any> | undefined
   constructor(private readonly input: T) {
     const {pickBy} = m.util
-    this.currentFlag = null
+    this.currentFlag = undefined
     this.context = input.context || {}
     this.argv = input.argv.slice(0)
     this._setNames()

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -47,10 +47,9 @@ export class Parser<T extends ParserInput, TFlags extends OutputFlags<T['flags']
   private readonly raw: ParsingToken[] = []
   private readonly booleanFlags: { [k: string]: Flags.IBooleanFlag<any> }
   private readonly context: any
-  private currentFlag: Flags.IOptionFlag<any> | undefined
+  private currentFlag?: Flags.IOptionFlag<any>
   constructor(private readonly input: T) {
     const {pickBy} = m.util
-    this.currentFlag = undefined
     this.context = input.context || {}
     this.argv = input.argv.slice(0)
     this._setNames()

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -47,10 +47,10 @@ export class Parser<T extends ParserInput, TFlags extends OutputFlags<T['flags']
   private readonly raw: ParsingToken[] = []
   private readonly booleanFlags: { [k: string]: Flags.IBooleanFlag<any> }
   private readonly context: any
-  private _currentFlag: Flags.IOptionFlag<any> | null
+  private currentFlag: Flags.IOptionFlag<any> | null
   constructor(private readonly input: T) {
     const {pickBy} = m.util
-    this._currentFlag = null
+    this.currentFlag = null
     this.context = input.context || {}
     this.argv = input.argv.slice(0)
     this._setNames()
@@ -94,7 +94,7 @@ export class Parser<T extends ParserInput, TFlags extends OutputFlags<T['flags']
       }
       const flag = this.input.flags[name]
       if (flag.type === 'option') {
-        this._currentFlag = flag
+        this.currentFlag = flag
         let input
         if (long || arg.length < 3) {
           input = this.argv.shift()
@@ -128,8 +128,8 @@ export class Parser<T extends ParserInput, TFlags extends OutputFlags<T['flags']
         }
         // not actually a flag if it reaches here so parse as an arg
       }
-      if (parsingFlags && this._currentFlag && this._currentFlag.multiple) {
-        this.raw.push({type: 'flag', flag: this._currentFlag.name, input})
+      if (parsingFlags && this.currentFlag && this.currentFlag.multiple) {
+        this.raw.push({type: 'flag', flag: this.currentFlag.name, input})
         continue
       }
       // not a flag, parse as arg

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -277,6 +277,33 @@ See more help with --help`)
     // })
   })
 
+  describe('flag with multiple inputs', () => {
+    it('flag multiple with flag in the middle', () => {
+      const out = parse(['--foo=bar', '--foo', '100', '--hello', 'world'], {
+        flags: {foo: flags.string({multiple: true}), hello: flags.string()},
+      })
+      expect(out.flags).to.deep.include({foo: ['bar', '100']})
+      expect(out.flags).to.deep.include({hello: 'world'})
+    })
+
+    it('flag multiple without flag in the middle', () => {
+      const out = parse(['--foo', './a.txt', './b.txt', './c.txt', '--hello', 'world'], {
+        flags: {foo: flags.string({multiple: true}), hello: flags.string()},
+      })
+      expect(out.flags).to.deep.include({foo: ['./a.txt', './b.txt', './c.txt']})
+      expect(out.flags).to.deep.include({hello: 'world'})
+    })
+
+    it('flag multiple with arguments', () => {
+      const out = parse(['--foo', './a.txt', './b.txt', './c.txt', '--', '15'], {
+        args: [{name: 'num'}],
+        flags: {foo: flags.string({multiple: true})},
+      })
+      expect(out.flags).to.deep.include({foo: ['./a.txt', './b.txt', './c.txt']})
+      expect(out.args).to.deep.include({num: '15'})
+    })
+  })
+
   describe('defaults', () => {
     it('defaults', () => {
       const out = parse([], {


### PR DESCRIPTION
## What
So far the parser supported flags with multiple inputs only if the flag shows before each input,
so this worked: ```MyCli mycmd -i foo -i bar```
but this didn't: ```MyCli mycmd -i foo bar```

## Why
When passing FS paths with wildcards, the paths are parsed by the terminal before they reach the oclif code. so if I type: ```MyCli readFiles -i ./files/*.txt``` the oclif will actually get ```MyCli readFiles -i ./files/a.txt ./files/b.txt ./files/c.txt``` and the command will fail.
I needed a way to allow my users to select multiple files in one command, so this functionality was needed.

## How
I kept a copy of the last flag parsed. if the next string in argv is not a flag, and the last flag parsed is accepting multiple values, the string will be added as a value for this flag.