### PR TITLE
Have implementation for `--no-*` flags reflect documentation.

### DIFF
--- a/src/flags.ts
+++ b/src/flags.ts
@@ -64,7 +64,7 @@ export function boolean<T = boolean>(options: Partial<IBooleanFlag<T>> = {}): IB
   return {
     parse: (b, _) => b,
     ...options,
-    allowNo: !!options.allowNo,
+    allowNo: options.allowNo !== false,
     type: 'boolean',
   } as IBooleanFlag<T>
 }

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -15,6 +15,25 @@ describe('parse', () => {
     expect(out).to.deep.include({flags: {bool: true}})
   })
 
+  it('--no-bool works by default', () => {
+    const out = parse(['--no-bool'], {
+      flags: {
+        bool: flags.boolean(),
+      },
+    })
+    expect(out).to.deep.include({flags: {bool: false}})
+  })
+
+  it('--no-bool is disabled with allowNo', () => {
+    expect(() => {
+      parse(['--no-bool'], {
+        flags: {
+          bool: flags.boolean({allowNo: false}),
+        },
+      })
+    }).to.throw(/Unexpected argument: --no-bool/)
+  })
+
   it('arg1', () => {
     const out = parse(['arg1'], {
       args: [{name: 'foo'}],


### PR DESCRIPTION
The [current documentation](https://oclif.io/docs/flags.html#alternative-flag-inputs) does not reflect the actual implementation. _Quoting from that documentation_
> ```js
> // flag with no value (-f, --force)
> force: flags.boolean({
>   char: 'f',
>   // by default boolean flags may also be reversed with `--no-` (in this case: `--no-force`)
>   // the flag will be set to false if reversed
>   // set this to false to disable this functionality
>   // allowNo: false,
> }),
> ```

In cases such as this there can only be two outcomes: the docs are wrong, or the implementation is wrong. This PR assumes the implementation is wrong and updates the behavior to reflect the docs.

> Remark: the documentation itself is somewhat ambiguous, but _"set this to false to disable this functionality"_ implies that it is enabled by default. 