### PR TITLE
Allow for { default } values on boolean flags

### DIFF
--- a/src/flags.ts
+++ b/src/flags.ts
@@ -21,6 +21,7 @@ export type IFlagBase<T, I> = {
 
 export type IBooleanFlag<T> = IFlagBase<T, boolean> & {
   type: 'boolean'
+  default?: T | ((context: DefaultContext<T>) => T | undefined)
   allowNo: boolean
 }
 

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -185,17 +185,17 @@ export class Parser<T extends ParserInput, TFlags extends OutputFlags<T['flags']
     }
     for (const k of Object.keys(this.input.flags)) {
       const flag = this.input.flags[k]
-      if (flags[k] || flag.type !== 'option') continue
-      if (flag.env) {
-        let input = process.env[flag.env]
-        if (input) flags[k] = flag.parse(input, this.context)
-      }
       if (!flags[k] && flag.default) {
         if (typeof flag.default === 'function') {
           flags[k] = flag.default({options: flag, flags, ...this.context})
         } else {
           flags[k] = flag.default
         }
+      }
+      if (flags[k] || flag.type !== 'option') continue
+      if (flag.env) {
+        let input = process.env[flag.env]
+        if (input) flags[k] = flag.parse(input, this.context)
       }
     }
     return flags

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -325,6 +325,16 @@ See more help with --help`)
       expect(out).to.deep.include({flags: {bool: true, yes: true}})
     })
 
+    it('--bool --no-yes (default: true)', () => {
+      const out = parse(['--bool'], {
+        flags: {
+          bool: flags.boolean(),
+          yes: flags.boolean({default: true, allowNo: true})
+        },
+      })
+      expect(out).to.deep.include({flags: {bool: true, yes: false}})
+    })
+
     it('default as function', () => {
       const out = parse([], {
         args: [{name: 'baz', default: () => 'BAZ'}],

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -315,6 +315,16 @@ See more help with --help`)
       expect(out.flags).to.deep.include({foo: 'bar'})
     })
 
+    it('--bool (default: true)', () => {
+      const out = parse(['--bool'], {
+        flags: {
+          bool: flags.boolean(),
+          yes: flags.boolean({default: true})
+        },
+      })
+      expect(out).to.deep.include({flags: {bool: true, yes: true}})
+    })
+
     it('default as function', () => {
       const out = parse([], {
         args: [{name: 'baz', default: () => 'BAZ'}],


### PR DESCRIPTION
> This is related to, but not blocked by https://github.com/oclif/parser/pull/33

The [current documentation](https://oclif.io/docs/flags.html#alternative-flag-inputs) does not reflect the actual implementation. _Quoting from that documentation_
> ```js
> static flags = {
>   name: flags.string({
>     char: 'n',                    // shorter flag version
>     description: 'name to print', // help description for flag
>     hidden: false,                // hide from help
>     multiple: false,              // allow setting this flag multiple times
>     env: 'MY_NAME',               // default to value of environment variable
>     options: ['a', 'b'],          // only allow the value to be from a discrete set
>     parse: input => 'output',     // instead of the user input, return a different value
>     default: 'world',             // default value if flag not passed
>     required: false,              // make flag required (this is not common and you should probably use an argument instead)
>     dependsOn: ['extra-flag'],    // this flag requires another flag
>     exclusive: ['extra-flag'],    // this flag cannot be specified alongside this other flag
>   }),
> 
>   // flag with no value (-f, --force)
>   force: flags.boolean({
>     char: 'f',
>     // by default boolean flags may also be reversed with `--no-` (in this case: `--no-force`)
>     // the flag will be set to false if reversed
>     // set this to false to disable this functionality
>     // allowNo: false,
>   }),
> }
> ```

The above documentation implies that this should work:

``` js
static flags = {
  force: flags.boolean({
    char: 'f',
    default: true // <–– this does NOT work
  });
}
```

This PR attempts to add `{default}` value support. **It is currently blocked** on a failing test that I can't figure out how to unbreak. Specifically that somehow `--bool` is "unexpected" when `--bool --no-yes` are provided:

```
 1) parse
       defaults
         --bool --no-yes (default: true):
     Error: Unexpected argument: --bool 
See more help with --help
      at validateArgs (src/validate.ts:11:13)
      at Object.validate (src/validate.ts:39:3)
      at Object.parse (src/index.ts:37:5)
      at Context.it (test/parse.test.ts:329:19)
```

> Remark: for anyone reading this "default" boolean values can be inferred by existential operators (i.e. not `undefined` or `'flag' in flags`). It is plausible that this is the expected interaction with the framework, but if so, it should be documented.