### PR TITLE
Allow a default to be specified for boolean flags

### DIFF
--- a/src/flags.ts
+++ b/src/flags.ts
@@ -22,6 +22,10 @@ export type IFlagBase<T, I> = {
 export type IBooleanFlag<T> = IFlagBase<T, boolean> & {
   type: 'boolean'
   allowNo: boolean
+  /**
+   * specifying a default of false is the same not specifying a default
+   */
+  default?: boolean | ((context: DefaultContext<boolean>) => boolean)
 }
 
 export type IOptionFlag<T> = IFlagBase<T, string> & {

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -185,12 +185,12 @@ export class Parser<T extends ParserInput, TFlags extends OutputFlags<T['flags']
     }
     for (const k of Object.keys(this.input.flags)) {
       const flag = this.input.flags[k]
-      if (flags[k] || flag.type !== 'option') continue
-      if (flag.env) {
+      if (flags[k]) continue
+      if (flag.type === 'option' && flag.env) {
         let input = process.env[flag.env]
         if (input) flags[k] = flag.parse(input, this.context)
       }
-      if (!flags[k] && flag.default) {
+      if (!(k in flags) && flag.default !== undefined) {
         if (typeof flag.default === 'function') {
           flags[k] = flag.default({options: flag, flags, ...this.context})
         } else {

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -359,6 +359,53 @@ See more help with --help`)
     })
   })
 
+  describe('boolean defaults', () => {
+    it('default is true', () => {
+      const out = parse([], {
+        flags: {
+          color: flags.boolean({default: true})
+        }
+      })
+      expect(out).to.deep.include({flags: {color: true}})
+    })
+
+    it('default is false', () => {
+      const out = parse([], {
+        flags: {
+          color: flags.boolean({default: false})
+        }
+      })
+      expect(out).to.deep.include({flags: {color: false}})
+    })
+
+    it('default as function', () => {
+      const out = parse([], {
+        flags: {
+          color: flags.boolean({default: () => true})
+        }
+      })
+      expect(out).to.deep.include({flags: {color: true}})
+    })
+
+    it('overridden true default', () => {
+      const out = parse(['--no-color'], {
+        flags: {
+          color: flags.boolean({allowNo: true, default: true})
+        }
+      })
+      expect(out).to.deep.include({flags: {color: false}})
+    })
+
+    it('overridden false default', () => {
+      const out = parse(['--color'], {
+        flags: {
+          color: flags.boolean({default: false})
+        }
+      })
+      expect(out).to.deep.include({flags: {color: true}})
+    })
+  })
+
   describe('custom option', () => {
     it('can pass parse fn', () => {
       const foo = flags.option({char: 'f', parse: () => 100})


### PR DESCRIPTION
This allows the use of boolean flag semantics where the default behavior for the application is as if `--flag` had been passed, and `--no-flag` is not the default behavior.