### PR TITLE
WIP: If an argument that is required (with no default) is missing, the parser does not throw a RequiredArgsError error 

### DIFF
--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -159,6 +159,20 @@ arg2  arg2 desc
 arg3  arg3 desc
 See more help with --help`)
       })
+
+      it('requires required arg followed by optional arg that has a default', () => {
+        expect(() => {
+          parse([], {
+            args: [
+              {name: 'arg1', required: true},
+              {name: 'arg2', required: false, default: 'some_default'},
+            ],
+          })
+        }).to.throw(`Missing 1 required arg:
+arg1
+See more help with --help`)
+      })
+
       it('too many args', () => {
         expect(() => {
           parse(['arg1', 'arg2'], {


### PR DESCRIPTION
See #42 
Work in Progress - failing test added first