### PR TITLE
feat: Add 'charOnly' flag option

### DIFF
--- a/src/flags.ts
+++ b/src/flags.ts
@@ -7,6 +7,7 @@ export type DefaultContext<T> = { options: IOptionFlag<T>; flags: { [k: string]:
 export type IFlagBase<T, I> = {
   name: string
   char?: AlphabetLowercase | AlphabetUppercase
+  charOnly?: boolean
   description?: string
   hidden?: boolean
   required?: boolean

--- a/src/help.ts
+++ b/src/help.ts
@@ -12,7 +12,7 @@ export interface FlagUsageOptions { displayRequired?: boolean }
 export function flagUsage(flag: IFlag<any>, options: FlagUsageOptions = {}): [string, string | undefined] {
   const label = []
   if (flag.char) label.push(`-${flag.char}`)
-  if (flag.name) label.push(` --${flag.name}`)
+  if (flag.name && !flag.charOnly) label.push(` --${flag.name}`)
 
   const usage = flag.type === 'option' ? ` ${flag.name.toUpperCase()}` : ''
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,14 @@
 // tslint:disable interface-over-type-literal
 
 import * as args from './args'
-import {OutputArgs, OutputFlags, Parser, ParserOutput as Output} from './parse'
-export {args}
+import Deps from './deps'
 import * as flags from './flags'
+import {OutputArgs, OutputFlags, Parser, ParserOutput as Output} from './parse'
 import * as Validate from './validate'
+
+export {args}
 export {flags}
 export {flagUsages} from './help'
-import Deps from './deps'
 
 const m = Deps()
 .add('validate', () => require('./validate').validate as typeof Validate.validate)

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -66,12 +66,13 @@ export class Parser<T extends ParserInput, TFlags extends OutputFlags<T['flags']
 
     const findLongFlag = (arg: string) => {
       const name = arg.slice(2)
-      if (this.input.flags[name]) {
+      const flag = this.input.flags[name]
+      if (flag && !flag.charOnly) {
         return name
       }
       if (arg.startsWith('--no-')) {
         const flag = this.booleanFlags[arg.slice(5)]
-        if (flag && flag.allowNo) return flag.name
+        if (flag && flag.allowNo && !flag.charOnly) return flag.name
       }
     }
 

--- a/test/help.test.ts
+++ b/test/help.test.ts
@@ -13,10 +13,12 @@ describe('flagUsage', () => {
       flags.string({name: 'baz', description: 'baz'}),
       flags.string({name: 'bar', char: 'b', description: 'bar'}),
       flags.string({name: 'foo', char: 'f', description: 'desc'}),
+      flags.string({name: 'goo', char: 'g', charOnly: true}),
     ]
     expect(flagUsages(f)).to.deep.equal([
       [' -b, --bar BAR', 'bar'],
       [' -f, --foo FOO', 'desc'],
+      [' -g GOO', undefined],
       [' --bak BAK', undefined],
       [' --baz BAZ', 'baz'],
     ])

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -105,6 +105,39 @@ describe('parse', () => {
       expect(out.flags).to.deep.equal({myflag: 'foo'})
     })
 
+    it('parses short flags only', () => {
+      const out = parse(['-m=foo'], {
+        flags: {
+          myflag: flags.string({char: 'm', charOnly: true}),
+        },
+      })
+      expect(out.flags).to.deep.equal({myflag: 'foo'})
+    })
+
+    it('fails when only short flag is accepted and given long flag', () => {
+      expect(() => {
+        parse(['--myflag=foo'], {
+          flags: {
+            myflag: flags.string({char: 'm', charOnly: true}),
+          },
+        })
+      }).to.throw('Unexpected argument: --myflag=foo')
+    })
+
+    it('fails when only short flag is accepted and given long flag with no', () => {
+      expect(() => {
+        parse(['--no-myflag'], {
+          flags: {
+            myflag: flags.boolean({
+              char: 'm',
+              charOnly: true,
+              allowNo: true
+            }),
+          },
+        })
+      }).to.throw('Unexpected argument: --no-myflag')
+    })
+
     it('parses value of ""', () => {
       const out = parse(['-m', ''], {
         flags: {


### PR DESCRIPTION
This feature adds a new flag option (charOnly) which, when set, disables
support for the long version and does not report the long version when
displaying usage.