### PR TITLE
feat: Add 'helpLabel' flag option

### DIFF
--- a/src/flags.ts
+++ b/src/flags.ts
@@ -8,6 +8,7 @@ export type IFlagBase<T, I> = {
   name: string
   char?: AlphabetLowercase | AlphabetUppercase
   description?: string
+  helpLabel?: string
   hidden?: boolean
   required?: boolean
   dependsOn?: string[],

--- a/src/help.ts
+++ b/src/help.ts
@@ -11,8 +11,13 @@ const m = Deps()
 export interface FlagUsageOptions { displayRequired?: boolean }
 export function flagUsage(flag: IFlag<any>, options: FlagUsageOptions = {}): [string, string | undefined] {
   const label = []
-  if (flag.char) label.push(`-${flag.char}`)
-  if (flag.name) label.push(` --${flag.name}`)
+
+  if (flag.helpLabel) {
+    label.push(flag.helpLabel)
+  } else {
+    if (flag.char) label.push(`-${flag.char}`)
+    if (flag.name) label.push(` --${flag.name}`)
+  }
 
   const usage = flag.type === 'option' ? ` ${flag.name.toUpperCase()}` : ''
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,14 @@
 // tslint:disable interface-over-type-literal
 
 import * as args from './args'
-import {OutputArgs, OutputFlags, Parser, ParserOutput as Output} from './parse'
-export {args}
+import Deps from './deps'
 import * as flags from './flags'
+import {OutputArgs, OutputFlags, Parser, ParserOutput as Output} from './parse'
 import * as Validate from './validate'
+
+export {args}
 export {flags}
 export {flagUsages} from './help'
-import Deps from './deps'
 
 const m = Deps()
 .add('validate', () => require('./validate').validate as typeof Validate.validate)

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,6 @@ import Deps from './deps'
 import * as flags from './flags'
 import {OutputArgs, OutputFlags, Parser, ParserOutput as Output} from './parse'
 import * as Validate from './validate'
-
 export {args}
 export {flags}
 export {flagUsages} from './help'

--- a/test/help.test.ts
+++ b/test/help.test.ts
@@ -14,11 +14,13 @@ describe('flagUsage', () => {
       flags.string({name: 'bar', char: 'b', description: 'bar'}),
       flags.string({name: 'foo', char: 'f', description: 'desc'}),
       flags.string({name: 'foo', char: 'f', helpLabel: '-f'}),
+      flags.boolean({char: 'g', description: 'goo'}),
     ]
     expect(flagUsages(f)).to.deep.equal([
       [' -b, --bar BAR', 'bar'],
       [' -f, --foo FOO', 'desc'],
       [' -f FOO', undefined],
+      [' -g', 'goo'],
       [' --bak BAK', undefined],
       [' --baz BAZ', 'baz'],
     ])

--- a/test/help.test.ts
+++ b/test/help.test.ts
@@ -13,10 +13,12 @@ describe('flagUsage', () => {
       flags.string({name: 'baz', description: 'baz'}),
       flags.string({name: 'bar', char: 'b', description: 'bar'}),
       flags.string({name: 'foo', char: 'f', description: 'desc'}),
+      flags.string({name: 'foo', char: 'f', helpLabel: '-f'}),
     ]
     expect(flagUsages(f)).to.deep.equal([
       [' -b, --bar BAR', 'bar'],
       [' -f, --foo FOO', 'desc'],
+      [' -f FOO', undefined],
       [' --bak BAK', undefined],
       [' --baz BAZ', 'baz'],
     ])


### PR DESCRIPTION
This feature adds a new flag option (helpLabel) which takes the place of the
flag label when displaying flag usage.

https://github.com/oclif/plugin-help/issues/37