### PR TITLE
fix: edge cases for integers flags

### DIFF
--- a/src/flags.ts
+++ b/src/flags.ts
@@ -76,7 +76,7 @@ export function boolean<T = boolean>(options: Partial<IBooleanFlag<T>> = {}): IB
 
 export const integer = build({
   parse: input => {
-    if (!/^[0-9]+$/.test(input)) throw new Error(`Expected an integer but received: ${input}`)
+    if (!/^-?[0-9]+$/.test(input)) throw new Error(`Expected an integer but received: ${input}`)
     return parseInt(input, 10)
   },
 })

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -37,7 +37,7 @@ export function validate(parse: { input: ParserInput; output: ParserOutput<any, 
 
   function validateFlags() {
     for (let [name, flag] of Object.entries(parse.input.flags)) {
-      if (parse.output.flags[name]) {
+      if (parse.output.flags[name] !== undefined) {
         for (let also of flag.dependsOn || []) {
           if (!parse.output.flags[also]) {
             throw new CLIError(`--${also}= must also be provided when using --${name}=`)

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -321,6 +321,13 @@ See more help with --help`)
         expect(out.flags).to.deep.include({int: 100})
       })
 
+      it('parses negative integers', () => {
+        const out = parse(['--int', '-100'], {
+          flags: {int: flags.integer(), s: flags.string()},
+        })
+        expect(out.flags).to.deep.include({int: -100})
+      })
+
       it('does not parse strings', () => {
         expect(() => {
           parse(['--int', 's10'], {

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -321,11 +321,34 @@ See more help with --help`)
         expect(out.flags).to.deep.include({int: 100})
       })
 
-      it('parses negative integers', () => {
-        const out = parse(['--int', '-100'], {
+      it('parses zero', () => {
+        const out = parse(['--int', '0'], {
           flags: {int: flags.integer(), s: flags.string()},
         })
-        expect(out.flags).to.deep.include({int: -100})
+        expect(out.flags).to.deep.include({int: 0})
+      })
+
+      it('parses negative integers', () => {
+        const out = parse(['--int', '-123'], {
+          flags: {int: flags.integer(), s: flags.string()},
+        })
+        expect(out.flags).to.deep.include({int: -123})
+      })
+
+      it('does not parse floats', () => {
+        expect(() => {
+          parse(['--int', '3.14'], {
+            flags: {int: flags.integer()},
+          })
+        }).to.throw('Expected an integer but received: 3.14')
+      })
+
+      it('does not parse fractions', () => {
+        expect(() => {
+          parse(['--int', '3/4'], {
+            flags: {int: flags.integer()},
+          })
+        }).to.throw('Expected an integer but received: 3/4')
       })
 
       it('does not parse strings', () => {

--- a/test/validate.test.ts
+++ b/test/validate.test.ts
@@ -107,4 +107,33 @@ describe('validate', () => {
     validate({input, output})
   })
 
+  it('throws when required flag is undefined', () => {
+    const input = {
+      argv: [],
+      flags: {
+        foobar: {
+          description: 'foobar flag',
+          required: true,
+        },
+      },
+      args: [],
+      strict: true,
+      context: {},
+      '--': true
+    }
+
+    const output = {
+      args: {},
+      argv: [],
+      flags: {foobar: undefined},
+      raw: [],
+      metadata: {
+        flags: {}
+      }
+    }
+
+    // @ts-ignore
+    expect(validate.bind({input, output})).to.throw()
+  })
+
 })

--- a/test/validate.test.ts
+++ b/test/validate.test.ts
@@ -77,4 +77,34 @@ describe('validate', () => {
     // @ts-ignore
     validate({input, output})
   })
+
+  it('allows zero for integer', () => {
+    const input = {
+      argv: [],
+      flags: {
+        int: {
+          description: 'zero as integer',
+          required: true,
+        },
+      },
+      args: [],
+      strict: true,
+      context: {},
+      '--': true
+    }
+
+    const output = {
+      args: {},
+      argv: [],
+      flags: {int: 0},
+      raw: [],
+      metadata: {
+        flags: {}
+      }
+    }
+
+    // @ts-ignore
+    validate({input, output})
+  })
+
 })


### PR DESCRIPTION
`validateFlags` was not differentiating between `0` and `undefined` which prevented `0` from being accepted as an input for integer based flags.

`integer` did not include optional leading `-` preventing negative numbers from being accepted