### PR TITLE
Allow negative integers for flags.integer

### DIFF
--- a/src/flags.ts
+++ b/src/flags.ts
@@ -76,7 +76,7 @@ export function boolean<T = boolean>(options: Partial<IBooleanFlag<T>> = {}): IB
 
 export const integer = build({
   parse: input => {
-    if (!/^[0-9]+$/.test(input)) throw new Error(`Expected an integer but received: ${input}`)
+    if (!/^-?[0-9]+$/.test(input)) throw new Error(`Expected an integer but received: ${input}`)
     return parseInt(input, 10)
   },
 })

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -335,6 +335,22 @@ See more help with --help`)
         expect(out.flags).to.deep.include({int: -123})
       })
 
+      it('does not parse floats', () => {
+        expect(() => {
+          parse(['--int', '3.14'], {
+            flags: {int: flags.integer()},
+          })
+        }).to.throw('Expected an integer but received: 3.14')
+      })
+
+      it('does not parse fractions', () => {
+        expect(() => {
+          parse(['--int', '3/4'], {
+            flags: {int: flags.integer()},
+          })
+        }).to.throw('Expected an integer but received: 3/4')
+      })
+
       it('does not parse strings', () => {
         expect(() => {
           parse(['--int', 's10'], {

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -321,6 +321,20 @@ See more help with --help`)
         expect(out.flags).to.deep.include({int: 100})
       })
 
+      it('parses zero', () => {
+        const out = parse(['--int', '0'], {
+          flags: {int: flags.integer(), s: flags.string()},
+        })
+        expect(out.flags).to.deep.include({int: 0})
+      })
+
+      it('parses negative integers', () => {
+        const out = parse(['--int', '-123'], {
+          flags: {int: flags.integer(), s: flags.string()},
+        })
+        expect(out.flags).to.deep.include({int: -123})
+      })
+
       it('does not parse strings', () => {
         expect(() => {
           parse(['--int', 's10'], {


### PR DESCRIPTION
Integers include all numbers that can be expressed without a fractional component. This includes negative numbers but the existing implementation's regex did not allow a leading `-` character for negative numbers.

I've fixed the regex and added tests to verify that `flags.integer` correctly parses negative numbers and zero (Just to be sure 😉).