### PR TITLE
Should throw on invalid flags after multiple flags

### DIFF
--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -280,6 +280,14 @@ See more help with --help`)
         expect(out.flags.baz.toUpperCase()).to.equal('D')
         expect(out.flags.bar.join('|')).to.equal('a|b')
       })
+
+      it('throws on incorrect flag after multiple flags', () => {
+        expect(() => parse(['--bar', 'a', '--bar', 'b', '--invalid', 'abc'], {
+          flags: {
+            bar: flags.string({multiple: true}),
+          },
+        })).to.throw()
+      })
     })
 
     describe('strict: false', () => {


### PR DESCRIPTION
What is the current behavior?
-----------------------------
If the current behavior is a bug, please provide the steps to reproduce.

```sh
$ cmd --multiple-flags abc --multiple-flags bcd --invalid-flag
# No error
```

What is the expected behavior?
------------------------------

```sh
$ cmd --multiple-flags abc --multiple-flags bcd --invalid-flag
ERROR: Unexpected arguments: --invalid-flag
```

https://github.com/oclif/oclif/issues/249