### PR TITLE
Add better type for flags with default value

### DIFF
--- a/src/flags.ts
+++ b/src/flags.ts
@@ -4,6 +4,8 @@ import {AlphabetLowercase, AlphabetUppercase} from './alphabet'
 
 export type DefaultContext<T> = { options: IOptionFlag<T>; flags: { [k: string]: string } }
 
+export type Default<T> = T | ((context: DefaultContext<T>) => T)
+
 export type IFlagBase<T, I> = {
   name: string
   char?: AlphabetLowercase | AlphabetUppercase
@@ -26,13 +28,13 @@ export type IBooleanFlag<T> = IFlagBase<T, boolean> & {
   /**
    * specifying a default of false is the same not specifying a default
    */
-  default?: boolean | ((context: DefaultContext<boolean>) => boolean)
+  default?: Default<boolean>
 }
 
 export type IOptionFlag<T> = IFlagBase<T, string> & {
   type: 'option'
   helpValue?: string
-  default?: T | ((context: DefaultContext<T>) => T | undefined)
+  default?: Default<T | undefined>
   multiple: boolean
   input: string[]
   options?: string[]
@@ -40,7 +42,7 @@ export type IOptionFlag<T> = IFlagBase<T, string> & {
 
 export type Definition<T> = {
   (options: {multiple: true} & Partial<IOptionFlag<T>>): IOptionFlag<T[]>
-  (options: ({required: true} | {default: T}) & Partial<IOptionFlag<T>>): IOptionFlag<T>
+  (options: ({required: true} | {default: Default<T>}) & Partial<IOptionFlag<T>>): IOptionFlag<T>
   (options?: Partial<IOptionFlag<T>>): IOptionFlag<T | undefined>
 }
 

--- a/src/flags.ts
+++ b/src/flags.ts
@@ -40,7 +40,7 @@ export type IOptionFlag<T> = IFlagBase<T, string> & {
 
 export type Definition<T> = {
   (options: {multiple: true} & Partial<IOptionFlag<T>>): IOptionFlag<T[]>
-  (options: {required: true} & Partial<IOptionFlag<T>>): IOptionFlag<T>
+  (options: ({required: true} | {default: T}) & Partial<IOptionFlag<T>>): IOptionFlag<T>
   (options?: Partial<IOptionFlag<T>>): IOptionFlag<T | undefined>
 }
 

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -459,9 +459,10 @@ See more help with --help`)
     })
 
     it('default has options', () => {
+      const def: flags.Default<string | undefined> = ({options}) => options.description
       const out = parse([], {
         // args: [{ name: 'baz', default: () => 'BAZ' }],
-        flags: {foo: flags.string({description: 'bar', default: ({options}) => options.description})},
+        flags: {foo: flags.string({description: 'bar', default: def})},
       })
       // expect(out.args).to.deep.include({ baz: 'BAZ' })
       // expect(out.argv).to.deep.include(['BAZ'])
@@ -469,12 +470,11 @@ See more help with --help`)
     })
 
     it('can default to a different flag', () => {
+      const def: flags.Default<string | undefined> = opts => opts.flags.foo
       const out = parse(['--foo=bar'], {
         flags: {
           bar: flags.string({
-            default: opts => {
-              return opts.flags.foo
-            },
+            default: def,
           }),
           foo: flags.string(),
         },


### PR DESCRIPTION
A flag with a default value was being typed as as `T | undefined`. For example the following would not type:

```typescript
      const out = parse([], {
        flags: {
          foo: flags.string({ default: 'baz' }),
          bar: flags.integer({ default: 42 }),
        }
      })
      const foo: string = out.flags.foo;
      const bar: number = out.flags.bar;
```

I added a special case in the type for this, the same way that `required: true` works.

Making the flag required is a workaround to get the above to type, but this is undesirable because it incorrectly shows the flag as required in the help.