### PR TITLE
fix: `default` should be `T[]` when `multiple: true`

### DIFF
--- a/src/flags.ts
+++ b/src/flags.ts
@@ -41,7 +41,7 @@ export type IOptionFlag<T> = IFlagBase<T, string> & {
 }
 
 export type Definition<T> = {
-  (options: {multiple: true} & Partial<IOptionFlag<T>>): IOptionFlag<T[]>
+  (options: {multiple: true} & Partial<IOptionFlag<T[]>>): IOptionFlag<T[]>
   (options: ({required: true} | {default: Default<T>}) & Partial<IOptionFlag<T>>): IOptionFlag<T>
   (options?: Partial<IOptionFlag<T>>): IOptionFlag<T | undefined>
 }


### PR DESCRIPTION
When using the `multiple: true` option in a flag the `default` option should be an array.

For example:

```
  static flags = {
    foo: flags.string({
      char: 'f',
      description: 'test flag',
      multiple: true,
      default: ['a']
    }),
    bar: flags.integer({
      char: 'b',
      description: 'test flag two',
      multiple: true,
      default: [1, 2, 3]
    })
  }
```

In this way the type of `default` matches the type of the flag itself.