### PR TITLE
Add stopParsing flag to arg

### DIFF
--- a/src/args.ts
+++ b/src/args.ts
@@ -8,6 +8,7 @@ export interface IArg<T = string> {
   parse?: ParseFn<T>
   default?: T | (() => T)
   options?: string[]
+  stopParsing?: boolean
 }
 
 export interface ArgBase<T> {
@@ -18,6 +19,7 @@ export interface ArgBase<T> {
   default?: T | (() => T)
   input?: string
   options?: string[]
+  stopParsing?: boolean
 }
 
 export type RequiredArg<T> = ArgBase<T> & {

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -140,6 +140,10 @@ export class Parser<T extends ParserInput, TFlags extends OutputFlags<T['flags']
       const arg = this.input.args[this._argTokens.length]
       if (arg) arg.input = input
       this.raw.push({type: 'arg', input})
+      if (arg && arg.stopParsing) {
+        parsingFlags = false
+        continue
+      }
     }
     const argv = this._argv()
     const args = this._args(argv)


### PR DESCRIPTION
When an arg is parsed that has the stopParsing flag set, the parser
will stop trying to parse flags, and treat the rest of the input as
arguments. One use of this feature is to support commands similar
to `yarn run` and `docker run`, as in `yarn run [<runFlags>] <script>
[<args>]`, where `<args>` are not documented or known to yarn, they are
simply passed on to the script being run.

The stopParsing flag allows an oclif command to behave similarly. You can
configure a positional argument to be the end of the input that is parsed
for flags, preventing oclif from detecting flags that occur afterward,
allowing the command to exclusively handle the rest of the input
through argv.