### PR TITLE
fix: make `EnumFlagOptions#options` of type `T[]` instead of `string`

### DIFF
--- a/src/flags.ts
+++ b/src/flags.ts
@@ -47,7 +47,7 @@ export type Definition<T> = {
 }
 
 export type EnumFlagOptions<T> = Partial<IOptionFlag<T>> & {
-  options: string[];
+  options: T[];
 }
 
 export type IFlag<T> = IBooleanFlag<T> | IOptionFlag<T>


### PR DESCRIPTION
Fixes #67