### PR TITLE
fix: move @oclif/errors from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,12 +5,12 @@
   "author": "Jeff Dickey @jdxcode",
   "bugs": "https://github.com/oclif/parser/issues",
   "dependencies": {
+    "@oclif/errors": "^1.2.2",
     "@oclif/linewrap": "^1.0.0",
     "chalk": "^2.4.2",
     "tslib": "^1.9.3"
   },
   "devDependencies": {
-    "@oclif/errors": "^1.2.2",
     "@types/chai": "^4.1.7",
     "@types/mocha": "^5.2.6",
     "@types/nock": "^9.3.1",


### PR DESCRIPTION
**What's the problem this PR addresses?**

`@oclif/parser` uses `@oclif/errors` at runtime but doesn't declare it as a dependency, this causes Yarn in PnP mode to reject access to the package. When using `node_modules` this causes `@oclif/parser` to rely on hoisting which is not guaranteed to place it in a location where we can access it.

**How did you fix it?**

Moved `@oclif/errors` from `devDependencies` to `dependencies`