### PR TITLE
fix: Allow parsing to anything

### DIFF
--- a/src/args.ts
+++ b/src/args.ts
@@ -1,7 +1,7 @@
 export type ParseFn<T> = (input: string) => T
 
 // eslint-disable-next-line @typescript-eslint/interface-name-prefix
-export interface IArg<T = string> {
+export interface IArg<T = any> {
   name: string;
   description?: string;
   required?: boolean;

--- a/src/args.ts
+++ b/src/args.ts
@@ -1,7 +1,7 @@
 export type ParseFn<T> = (input: string) => T
 
 // eslint-disable-next-line @typescript-eslint/interface-name-prefix
-export interface IArg<T = any> {
+export interface IArg<T = string> {
   name: string;
   description?: string;
   required?: boolean;


### PR DESCRIPTION
This closes oclif/oclif#337

This simply changes the type to any so people can parse to whatever they see fit.