### PR TITLE
feat: Add 'singleValue' flag option to assign only one value per multiple flag

### DIFF
--- a/src/flags.ts
+++ b/src/flags.ts
@@ -36,6 +36,7 @@ export type IOptionFlag<T> = IFlagBase<T, string> & {
   helpValue?: string;
   default?: Default<T | undefined>;
   multiple: boolean;
+  singleValue: boolean;
   input: string[];
   options?: string[];
 }
@@ -62,6 +63,7 @@ export function build<T>(defaults: Partial<IOptionFlag<T>>): Definition<T> {
       ...options,
       input: [] as string[],
       multiple: Boolean(options.multiple),
+      singleValue: Boolean(options.singleValue),
       type: 'option',
     } as any
   }

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -141,7 +141,7 @@ export class Parser<T extends ParserInput, TFlags extends OutputFlags<T['flags']
         }
         // not actually a flag if it reaches here so parse as an arg
       }
-      if (parsingFlags && this.currentFlag && this.currentFlag.multiple) {
+      if (parsingFlags && this.currentFlag && this.currentFlag.multiple && !this.currentFlag.singleValue) {
         this.raw.push({type: 'flag', flag: this.currentFlag.name, input})
         continue
       }

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -290,6 +290,42 @@ See more help with --help`)
       })
     })
 
+    describe('multiple flags with single value', () => {
+      it('parses multiple flags with single value', () => {
+        const out = parse(['--bar', 'a', 'b', '--bar=c', '--baz=d', 'e'], {
+          args: [{name: 'argOne'}],
+          flags: {
+            bar: flags.string({multiple: true, singleValue: true}),
+            baz: flags.string({multiple: true}),
+          },
+        })
+        expect(out.flags.baz.join('|')).to.equal('d|e')
+        expect(out.flags.bar.join('|')).to.equal('a|c')
+        expect(out.args).to.deep.equal({argOne: 'b'})
+      })
+
+      it('parses multiple flags with single value multiple args', () => {
+        const out = parse(['c', '--bar', 'a', 'b'], {
+          args: [{name: 'argOne'}, {name: 'argTwo'}],
+          flags: {
+            bar: flags.string({multiple: true, singleValue: true}),
+          },
+        })
+        expect(out.flags.bar.join('|')).to.equal('a')
+        expect(out.args).to.deep.equal({argOne: 'c', argTwo: 'b'})
+      })
+
+      it('fails to parse with single value and no args option', () => {
+        expect(() => {
+          parse(['--bar', 'a', 'b'], {
+            flags: {
+              bar: flags.string({multiple: true, singleValue: true}),
+            },
+          })
+        }).to.throw('Unexpected argument: b')
+      })
+    })
+
     describe('strict: false', () => {
       it('skips flag parsing after "--"', () => {
         const out = parse(['foo', 'bar', '--', '--myflag'], {


### PR DESCRIPTION
This feature aims to address the issue outlined in https://github.com/oclif/oclif/issues/190 to only allow a single value to be assigned for each flag that has the `multiple` option set. It's a non-breaking change that requires you to include the `singleValue` boolean in your flag options.

In the command `cmd -a foo bar`, it's generally accepted that `bar` becomes a positional argument and should be the default behaviour. Unfortunately, the [PR](https://github.com/oclif/parser/pull/25) that broke default behaviour has been part of this project for a while now and I feel providing the user an option to change this back would be the best course of action unless a breaking release is planned for oclif.

If this goes through, I'll update and push the relevant changes to the [docs repository](https://github.com/oclif/oclif.github.io).