### PR TITLE
Stop processing Flag multiple when another flag is found

### DIFF
--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -426,6 +426,58 @@ See more help with --help`)
       expect(out.flags).to.deep.include({hello: 'world'})
     })
 
+    it('ends when a flag that wants input is found', () => {
+      const out = parse(
+        ['--foo', './a.txt', './b.txt', './c.txt', '--bar', 'world', 'me'],
+        {
+          flags: {
+            foo: flags.string({multiple: true}),
+            bar: flags.string(),
+          },
+          args: [{name: 'arg', required: false}],
+        },
+      )
+      expect(out.flags).to.deep.include({
+        foo: ['./a.txt', './b.txt', './c.txt'],
+      })
+      expect(out.flags).to.deep.include({bar: 'world'})
+      expect(out.argv).to.deep.equal(['me'])
+    })
+    it('ends when a flag that does not want input is found', () => {
+      const out = parse(
+        ['--foo', './a.txt', './b.txt', './c.txt', '--bar', 'world'],
+        {
+          flags: {
+            foo: flags.string({multiple: true}),
+            bar: flags.boolean(),
+          },
+          args: [{name: 'arg', required: false}],
+        },
+      )
+      expect(out.flags).to.deep.include({
+        foo: ['./a.txt', './b.txt', './c.txt'],
+      })
+      expect(out.flags).to.deep.include({bar: true})
+      expect(out.argv).to.deep.equal(['world'])
+    })
+    it('ends when next flag is found with strict=false', () => {
+      const out = parse(
+        ['--foo', './a.txt', './b.txt', './c.txt', '--bar', 'world'],
+        {
+          flags: {
+            foo: flags.string({multiple: true}),
+            bar: flags.boolean(),
+          },
+          strict: false,
+        },
+      )
+      /* expect(out.flags).to.deep.include({
+        foo: ['./a.txt', './b.txt', './c.txt'],
+      }) */
+      expect(out.flags).to.deep.include({bar: true})
+      expect(out.argv).to.deep.equal(['world'])
+    })
+
     it('flag multiple with arguments', () => {
       const out = parse(
         ['--foo', './a.txt', './b.txt', './c.txt', '--', '15'],


### PR DESCRIPTION
WIP. Added basic tests. Suspecting bug is due to `this.currentFlag` not being set for non-options in [parse.ts line109-147](https://github.com/oclif/parser/blob/69e17dd28a87588151f234437a68c6b3359d7a46/src/parse.ts#L109-L147)
Possibly related issues
https://github.com/oclif/oclif/issues/190
https://github.com/oclif/oclif/issues/261