### PR TITLE
fix: print valid flag values in error message when using `exactlyOne`

### DIFF
--- a/src/validate.ts
+++ b/src/validate.ts
@@ -53,8 +53,8 @@ export function validate(parse: {
     if (intersection.length === 0) {
       // the command's exactlyOne may or may not include itself, so we'll use Set to add + de-dupe
       throw new CLIError(`Exactly one of the following must be provided: ${[
-        ...new Set(...flag.exactlyOne || [], flag.name),
-      ].join(',')}`)
+        ...new Set(flag.exactlyOne),
+      ].join(', ')}`)
     }
   }
 

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -719,11 +719,11 @@ See more help with --help`)
       expect(() => {
         parse([], {
           flags: {
-            foo: flags.string({exactlyOne: ['bar']}),
-            bar: flags.string({char: 'b', exactlyOne: ['foo']}),
+            foo: flags.string({exactlyOne: ['bar', 'foo']}),
+            bar: flags.string({char: 'b', exactlyOne: ['bar', 'foo']}),
           },
         })
-      }).to.throw()
+      }).to.throws('Exactly one of the following must be provided: bar, foo')
     })
 
     it('throws if multiple are set', () => {


### PR DESCRIPTION
When a flag uses the `exactlyOne` flag property in one command and then you run the command without passing any flag you get a wrong error message.

```bash
sfdx force:source:deploy
ERROR running force:source:deploy:  Exactly one of the following must be provided: m,a,n,i,f,e,s,t
```

`xorFlags`: https://github.com/salesforcecli/plugin-source/blob/172fd88894f5e631655afb916f848e372acb5c8b/src/commands/force/source/deploy.ts#L26

With this fix:
```bash
sfdx force:source:deploy
ERROR running force:source:deploy:  Exactly one of the following must be provided: manifest, metadata, sourcepath, validateddeployrequestid
```