### PR TITLE
fix TFlags constraint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ export type Input<TFlags extends flags.Output> = {
   '--'?: boolean;
 }
 
-export function parse<TFlags, TArgs extends {[name: string]: string}>(argv: string[], options: Input<TFlags>): Output<TFlags, TArgs> {
+export function parse<TFlags extends flags.Output, TArgs extends {[name: string]: string}>(argv: string[], options: Input<TFlags>): Output<TFlags, TArgs> {
   const input = {
     argv,
     context: options.context,


### PR DESCRIPTION
This makes it compatible with TypeScript 4.8

Before this change, you get an error:

```
node_modules/@oclif/parser/lib/index.d.ts:16:52 - error TS2344: Type 'TFlags' does not satisfy the constraint 'OutputFlags<any>'.

16 }>(argv: string[], options: Input<TFlags>): Output<TFlags, TArgs>;
                                                      ~~~~~~
```